### PR TITLE
Removed the equals sign in settings as this pattern is now deprecated

### DIFF
--- a/templates/default/lsyncd.conf.lua.erb
+++ b/templates/default/lsyncd.conf.lua.erb
@@ -1,6 +1,6 @@
 -- Managed by Chef
 
-settings = {
+settings {
   logfile = "<%= node[:lsyncd][:log_file] %>",
   statusFile = "<%= node[:lsyncd][:status_file] %>",
   statusInterval = <%= node[:lsyncd][:interval] %>


### PR DESCRIPTION
On newer versions of lsyncd such as 2.1.4, the service fails to start with the equals sign in lsyncd.conf.
