### PR TITLE
updates to have Redhat specific template for target

### DIFF
--- a/templates/redhat/target.erb
+++ b/templates/redhat/target.erb
@@ -1,0 +1,18 @@
+-- Created by Chef; Using lsync 2.1 config sytax
+sync {
+    default.<%= @mode %>,
+    source      = "<%= @source %>",
+<% if @mode == 'rsync' -%>
+    <% if @host -%>
+    target      = "<% if @user %><%= @user %>@<% end %><%= @host %>:<%= @target %>",
+    <% else -%>
+    target      = "<%= @target %>",
+    <% end -%>
+<% elsif @mode == 'rsyncssh' -%>
+    targetdir   = "<%= @target %>",
+    host        = "<%= @host %>",
+<% end -%>
+<%= "    rsync = {\n      _extra = #{@rsync_opts},\n    }," if @rsync_opts -%>
+<%= "    exclude     = #{@exclude},\n" if @exclude -%>
+<%= "    excludeFrom = \"#{@exclude_from}\",\n" if @exclude_from -%>
+}


### PR DESCRIPTION
Currently, there is a target template for CentOS, but not for Redhat. As such, Redhat gets the default target template, which has 'rsyncOps = ' instead of 'rsync = { ...}', which causes lsync not to start on RHEL systems. This PR simply copies the CentOS target template into a redhat template so it doesn't use default, and works properly in my testing.
