### PR TITLE
updates to add support for Ubuntu 14, which has 2.1 instead of 2.0

### DIFF
--- a/templates/ubuntu-14.04/target.erb
+++ b/templates/ubuntu-14.04/target.erb
@@ -1,0 +1,18 @@
+-- Created by Chef; Using lsync 2.1 config sytax
+sync {
+    default.<%= @mode %>,
+    source      = "<%= @source %>",
+<% if @mode == 'rsync' -%>
+    <% if @host -%>
+    target      = "<% if @user %><%= @user %>@<% end %><%= @host %>:<%= @target %>",
+    <% else -%>
+    target      = "<%= @target %>",
+    <% end -%>
+<% elsif @mode == 'rsyncssh' -%>
+    targetdir   = "<%= @target %>",
+    host        = "<%= @host %>",
+<% end -%>
+<%= "    rsync = {\n      _extra = #{@rsync_opts},\n    }," if @rsync_opts -%>
+<%= "    exclude     = #{@exclude},\n" if @exclude -%>
+<%= "    excludeFrom = \"#{@exclude_from}\",\n" if @exclude_from -%>
+}


### PR DESCRIPTION
Ubuntu 14.04 comes with 2.1 and so it needs the 2.1 template. I've confirmed this works still on older Ubuntus (where they get the default 2.0) and 14.04 (getting the 2.1). 
