### PR TITLE
Yum dependency and Amazon templates

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,4 +11,4 @@ supports         'scientific', '>= 6.0'
 supports         'redhat', '>= 6.0'
 supports         'amazon'
 version          '0.2.2'
-depends          'yum', "~> 3.0.0"
+depends          'yum', ">= 3.5.3"

--- a/templates/amazon/lsyncd.conf.lua.erb
+++ b/templates/amazon/lsyncd.conf.lua.erb
@@ -1,0 +1,11 @@
+-- Managed by Chef; Using lsync 2.1 config sytax
+
+settings {
+  logfile = "<%= node['lsyncd']['log_file'] %>",
+  statusFile = "<%= node['lsyncd']['status_file'] %>",
+  statusInterval = <%= node['lsyncd']['interval'] %>
+}
+
+-- Hacky way of doing conf.d style configs
+package.path = "/etc/lsyncd/conf.d/?.lua;" .. package.path
+local f = io.popen("ls /etc/lsyncd/conf.d/*.lua|xargs -n1 basename|sed 's/.lua//'") for mod in f:lines() do require(mod) end

--- a/templates/amazon/target.erb
+++ b/templates/amazon/target.erb
@@ -1,0 +1,18 @@
+-- Created by Chef; Using lsync 2.1 config sytax
+sync {
+    default.<%= @mode %>,
+    source      = "<%= @source %>",
+<% if @mode == 'rsync' -%>
+    <% if @host -%>
+    target      = "<% if @user %><%= @user %>@<% end %><%= @host %>:<%= @target %>",
+    <% else -%>
+    target      = "<%= @target %>",
+    <% end -%>
+<% elsif @mode == 'rsyncssh' -%>
+    targetdir   = "<%= @target %>",
+    host        = "<%= @host %>",
+<% end -%>
+<%= "    rsync = {\n      _extra = #{@rsync_opts},\n    },\n" if @rsync_opts -%>
+<%= "    exclude     = #{@exclude},\n" if @exclude -%>
+<%= "    excludeFrom = \"#{@exclude_from}\",\n" if @exclude_from -%>
+}


### PR DESCRIPTION
Yum dependency 3.0.0 in metadata is very old. Updated to a more recent one.

Add amazon templates (equal to the centos ones).
